### PR TITLE
Add admin-ajax verification fallback

### DIFF
--- a/src/API/Verify.php
+++ b/src/API/Verify.php
@@ -2,6 +2,7 @@
 
 namespace Endurance\WP\Module\Data\API;
 
+use Endurance\WP\Module\Data\HubConnection;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Response;
@@ -12,11 +13,20 @@ use WP_REST_Response;
 class Verify extends WP_REST_Controller {
 
 	/**
+	 * Instance of HubConnection class
+	 *
+	 * @var HubConnection
+	 */
+	public $hub;
+
+	/**
 	 * Constructor.
 	 *
+	 * @param HubConnection $hub Instance of the hub connection manager
 	 * @since 4.7.0
 	 */
-	public function __construct() {
+	public function __construct( HubConnection $hub ) {
+		$this->hub       = $hub;
 		$this->namespace = 'bluehost/v1/data';
 		$this->rest_base = 'verify';
 	}
@@ -60,16 +70,8 @@ class Verify extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$saved_token = get_transient( 'bh_data_verify_token' );
-
-		if ( $saved_token && $saved_token === $request['token'] ) {
-			$valid  = true;
-			$status = 200;
-			delete_transient( 'bh_data_verify_token' );
-		} else {
-			$valid  = false;
-			$status = 401;
-		}
+		$valid  = $this->hub->verify( $request['token'] );
+		$status = ( $valid ) ? 200 : 401;
 
 		$response = new WP_REST_Response(
 			array(

--- a/src/API/Verify.php
+++ b/src/API/Verify.php
@@ -70,7 +70,7 @@ class Verify extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$valid  = $this->hub->verify( $request['token'] );
+		$valid  = $this->hub->verify_token( $request['token'] );
 		$status = ( $valid ) ? 200 : 401;
 
 		$response = new WP_REST_Response(

--- a/src/Data.php
+++ b/src/Data.php
@@ -41,7 +41,7 @@ class Data {
 		// bail before registering the subscribers/listeners
 		if ( ! $this->hub->is_connected() ) {
 
-			// If we aren't connected, register the admin-ajax verification fallback
+			// Initialize the required verification endpoints
 			$this->hub->register_verification_hooks();
 
 			// Attempt to connect

--- a/src/Data.php
+++ b/src/Data.php
@@ -23,22 +23,9 @@ class Data {
 	 */
 	public function start() {
 
-		// Make sure all REST API routes are registered
-		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
-
 		// Delays our primary module setup until init
 		add_action( 'init', array( $this, 'init' ) );
 
-	}
-
-	/**
-	 * Set up REST API routes
-	 *
-	 * @return void
-	 */
-	public function rest_api_init() {
-		$controller = new API\Verify();
-		$controller->register_routes();
 	}
 
 	/**
@@ -53,6 +40,11 @@ class Data {
 		// If not connected, attempt to connect and
 		// bail before registering the subscribers/listeners
 		if ( ! $this->hub->is_connected() ) {
+
+			// If we aren't connected, register the admin-ajax verification fallback
+			$this->hub->register_verification_hooks();
+
+			// Attempt to connect
 			$this->hub->connect();
 			return;
 		}

--- a/src/HubConnection.php
+++ b/src/HubConnection.php
@@ -36,6 +36,43 @@ class HubConnection implements SubscriberInterface {
 	}
 
 	/**
+	 * Register the hooks required for site verification
+	 *
+	 * @return void
+	 */
+	public function register_verification_hooks() {
+		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
+
+	}
+
+	/**
+	 * Set up REST API routes
+	 *
+	 * @return void
+	 */
+	public function rest_api_init() {
+		$controller = new API\Verify( $this );
+		$controller->register_routes();
+	}
+
+	/**
+	 * Confirm whether verification token is valid
+	 *
+	 * @param string $token Token to verify
+	 * @return boolean
+	 */
+	public function verify( $token ) {
+		$saved_token = get_transient( 'bh_data_verify_token' );
+
+		if ( $saved_token && $saved_token === $token ) {
+			delete_transient( 'bh_data_verify_token' );
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check whether site has established connection to hub
 	 *
 	 * @return boolean

--- a/src/HubConnection.php
+++ b/src/HubConnection.php
@@ -42,6 +42,7 @@ class HubConnection implements SubscriberInterface {
 	 */
 	public function register_verification_hooks() {
 		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
+		add_action( 'wp_ajax_nopriv_bh-hub-verify', array( $this, 'ajax_verify' ) );
 
 	}
 
@@ -53,6 +54,22 @@ class HubConnection implements SubscriberInterface {
 	public function rest_api_init() {
 		$controller = new API\Verify( $this );
 		$controller->register_routes();
+	}
+
+	/**
+	 * Process the admin-ajax request
+	 *
+	 * @return void
+	 */
+	public function ajax_verify() {
+		$valid  = $this->verify( $_REQUEST['token'] );
+		$status = ( $valid ) ? 200 : 400;
+
+		$data = array(
+			'token' => $_REQUEST['token'],
+			'valid' => $valid,
+		);
+		wp_send_json( $data, $status );
 	}
 
 	/**

--- a/src/HubConnection.php
+++ b/src/HubConnection.php
@@ -62,7 +62,7 @@ class HubConnection implements SubscriberInterface {
 	 * @return void
 	 */
 	public function ajax_verify() {
-		$valid  = $this->verify( $_REQUEST['token'] );
+		$valid  = $this->verify_token( $_REQUEST['token'] );
 		$status = ( $valid ) ? 200 : 400;
 
 		$data = array(
@@ -78,7 +78,7 @@ class HubConnection implements SubscriberInterface {
 	 * @param string $token Token to verify
 	 * @return boolean
 	 */
-	public function verify( $token ) {
+	public function verify_token( $token ) {
 		$saved_token = get_transient( 'bh_data_verify_token' );
 
 		if ( $saved_token && $saved_token === $token ) {


### PR DESCRIPTION
If a site has the REST API restricted on only authenticated users, we can't verify the site using the normal `/verify` endpoint on REST API. 

This PR solves that and does a couple other things:
- Moves registration of the `/verify` endpoint into the `HubConnection` class
- Adds an `admin-ajax.php` verification endpoint to be used as a fallback when the REST API is unavailable
- Only initializes/registers the two verification endpoint options when a site is not connected. Once connected they aren't needed anymore, so we don't register them. 
