### PR TITLE
Add Options API fallback for unreliable Transients

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -45,7 +45,10 @@ class Data {
 			$this->hub->register_verification_hooks();
 
 			// Attempt to connect
-			$this->hub->connect();
+			if ( ! $this->hub->is_throttled() ) {
+				$this->hub->connect();
+			}
+
 			return;
 		}
 

--- a/src/HubConnection.php
+++ b/src/HubConnection.php
@@ -194,7 +194,7 @@ class HubConnection implements SubscriberInterface {
 
 		$data = get_option( $key );
 		if ( ! empty( $data ) ) {
-			if ( $data['expires'] > time() ) {
+			if ( isset( $data['expires'] ) && $data['expires'] > time() ) {
 				return $data['value'];
 			}
 		}

--- a/src/HubConnection.php
+++ b/src/HubConnection.php
@@ -182,7 +182,7 @@ class HubConnection implements SubscriberInterface {
 	}
 
 	/**
-	 * Custom override for get_transient() with Options API fallback
+	 * Custom wrapper for get_transient() with Options API fallback
 	 *
 	 * @param string $key The key of the transient to retrieve
 	 * @return mixed The value of the transient
@@ -203,7 +203,7 @@ class HubConnection implements SubscriberInterface {
 	}
 
 	/**
-	 * Custom override for set_transient() with Options API fallback
+	 * Custom wrapper for set_transient() with Options API fallback
 	 *
 	 * @param string  $key     Key to use for storing the transient
 	 * @param mixed   $value   Value to be saved
@@ -223,7 +223,7 @@ class HubConnection implements SubscriberInterface {
 	}
 
 	/**
-	 * Custom override for delete_transient() with Optiosn API fallback
+	 * Custom wrapper for delete_transient() with Optiosn API fallback
 	 *
 	 * @param string $key The key of the transient/option to delete
 	 * @return boolean Whether the value was deleted

--- a/src/Transient.php
+++ b/src/Transient.php
@@ -45,17 +45,18 @@ class Transient {
 	 *
 	 * @param string  $key     Key to use for storing the transient
 	 * @param mixed   $value   Value to be saved
-	 * @param integer $expires Optional expiration time
+	 * @param integer $expires Optional expiration time in seconds from now. Default is 1 hour
 	 * @return boolean Whether the value was saved
 	 */
-	public static function set( $key, $value, $expires = 60 * MINUTE_IN_SECONDS ) {
+	public static function set( $key, $value, $expires = null ) {
+		$expiration = ( $expires ) ? time() + $expires : time() + 60 * MINUTE_IN_SECONDS;
 		if ( self::should_use_transients() ) {
-			return set_transient( $key, $value, $expires );
+			return set_transient( $key, $value, $expiration );
 		}
 
 		$data = array(
 			'value'   => $value,
-			'expires' => $expires,
+			'expires' => $expiration,
 		);
 		return update_option( $key, $data, false );
 	}

--- a/src/Transient.php
+++ b/src/Transient.php
@@ -1,0 +1,76 @@
+<?php
+namespace Endurance\WP\Module\Data;
+
+/**
+ * Custom Transient class to handle an Options API based fallback
+ */
+class Transient {
+
+	/**
+	 * Whether to use transients to store temporary data
+	 *
+	 * If the site has an object-cache.php drop-in, then we can't reliably
+	 * use the transients API. We'll try to fall back to the options API.
+	 *
+	 * @return boolean
+	 */
+	public static function should_use_transients() {
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+		return ! array_key_exists( 'object-cache.php', get_dropins() );
+	}
+
+	/**
+	 * Wrapper for get_transient() with Options API fallback
+	 *
+	 * @param string $key The key of the transient to retrieve
+	 * @return mixed The value of the transient
+	 */
+	public static function get( $key ) {
+		if ( self::should_use_transients() ) {
+			return get_transient( $key );
+		}
+
+		$data = get_option( $key );
+		if ( ! empty( $data ) ) {
+			if ( isset( $data['expires'] ) && $data['expires'] > time() ) {
+				return $data['value'];
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Wrapper for set_transient() with Options API fallback
+	 *
+	 * @param string  $key     Key to use for storing the transient
+	 * @param mixed   $value   Value to be saved
+	 * @param integer $expires Optional expiration time
+	 * @return boolean Whether the value was saved
+	 */
+	public static function set( $key, $value, $expires = 60 * MINUTE_IN_SECONDS ) {
+		if ( self::should_use_transients() ) {
+			return set_transient( $key, $value, $expires );
+		}
+
+		$data = array(
+			'value'   => $value,
+			'expires' => $expires,
+		);
+		return update_option( $key, $data, false );
+	}
+
+	/**
+	 * Wrapper for delete_transient() with Options API fallback
+	 *
+	 * @param string $key The key of the transient/option to delete
+	 * @return boolean Whether the value was deleted
+	 */
+	public static function delete( $key ) {
+		if ( self::should_use_transients() ) {
+			return delete_transient( $key );
+		}
+
+		return delete_option( $key );
+	}
+}


### PR DESCRIPTION
## Proposed changes

If a site has an `object-cache.php` drop-in on their site, it's most likely misconfigured and we can't reliably use the transients API to determine whether the connection attempt should be throttled. This PR adds a fallback to use the standard options API which usually still works correctly. 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)