### PR TITLE
Fix jetpack connection errors

### DIFF
--- a/src/Listeners/Jetpack.php
+++ b/src/Listeners/Jetpack.php
@@ -14,7 +14,7 @@ class Jetpack extends Listener {
 	 */
 	public function register_hooks() {
 		// Connected
-		add_action( 'jetpack_log_entry', array( $this, 'connected' ), 10, 3 );
+		add_action( 'jetpack_site_registered', array( $this, 'connected' ), 10, 3 );
 
 		// Module enabled/disabled
 		add_action( 'jetpack_pre_activate_module', array( $this, 'module_enabled' ) );


### PR DESCRIPTION
## Proposed changes

In #4, we updated the parameters passed to more specifically listen for Jetpack connections and not hook into the general log to find them, which was a carryover from some older code. 

However, while the variables passed were updated, the specified action hook was not updated, leading to some fatal errors as reported in #9. 

This switches [the hook used](https://github.com/Automattic/jetpack/blob/bb27f0b0997b624ba5db5d2f0d45c36f900bd95b/packages/connection/src/class-manager.php#L932-L945) to `jetpack_site_registered`. 

Fixes #9 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

