### PR TITLE
Fix throttle transient timeout

### DIFF
--- a/src/Transient.php
+++ b/src/Transient.php
@@ -49,7 +49,7 @@ class Transient {
 	 * @return boolean Whether the value was saved
 	 */
 	public static function set( $key, $value, $expires = null ) {
-		$expiration = ( $expires ) ? time() + $expires : time() + 60 * MINUTE_IN_SECONDS;
+		$expiration = ( $expires ) ? $expires : 60 * MINUTE_IN_SECONDS;
 		if ( self::should_use_transients() ) {
 			return set_transient( $key, $value, $expiration );
 		}

--- a/src/Transient.php
+++ b/src/Transient.php
@@ -31,9 +31,11 @@ class Transient {
 		}
 
 		$data = get_option( $key );
-		if ( ! empty( $data ) ) {
-			if ( isset( $data['expires'] ) && $data['expires'] > time() ) {
+		if ( ! empty( $data ) && isset( $data['expires'] ) ) {
+			if ( $data['expires'] > time() ) {
 				return $data['value'];
+			} else {
+				delete_option( $key );
 			}
 		}
 
@@ -56,7 +58,7 @@ class Transient {
 
 		$data = array(
 			'value'   => $value,
-			'expires' => $expiration,
+			'expires' => $expiration + time(),
 		);
 		return update_option( $key, $data, false );
 	}


### PR DESCRIPTION
## Proposed changes

When I added the stepback to the throttle, we added the expiration to the current time, which means the transients won't expire until ~2071. 

This is a simple fix to the expiration time used in the transient. 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)