### PR TITLE
Use a queue for async events

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -53,7 +53,7 @@ class Data {
 		}
 
 		$manager = new EventManager();
-		$manager->initialize_listeners();
+		$manager->init();
 
 		$manager->add_subscriber( $this->hub );
 

--- a/src/Data.php
+++ b/src/Data.php
@@ -39,7 +39,7 @@ class Data {
 
 		// If not connected, attempt to connect and
 		// bail before registering the subscribers/listeners
-		if ( ! $this->hub->is_connected() ) {
+		if ( ! $this->hub::is_connected() ) {
 
 			// Initialize the required verification endpoints
 			$this->hub->register_verification_hooks();

--- a/src/Event.php
+++ b/src/Event.php
@@ -43,11 +43,11 @@ class Event {
 	public $user;
 
 	/**
-	 * Array of version data about the environment
+	 * Timestamp when the event occurred
 	 *
-	 * @var array
+	 * @var integer
 	 */
-	public $environment;
+	public $time;
 
 	/**
 	 * Construct
@@ -57,9 +57,10 @@ class Event {
 	 * @param array  $data     Additional data specific to the event that occurred
 	 */
 	public function __construct( $category = 'Admin', $key = '', $data = array() ) {
-		global $title, $wpdb, $wp_version;
+		global $title;
 
 		// Event details
+		$this->time     = time();
 		$this->category = strtolower( $category );
 		$this->key      = $key;
 		$this->data     = $data;
@@ -90,16 +91,6 @@ class Event {
 			'locale' => get_user_locale(),
 		);
 
-		// Environment Information
-		$this->environment = array(
-			'url'         => get_site_url(),
-			'php'         => phpversion(),
-			'mysql'       => $wpdb->db_version(),
-			'wp'          => $wp_version,
-			'plugin'      => BLUEHOST_PLUGIN_VERSION,
-			'hostname'    => gethostname(),
-			'cache_level' => intval( get_option( 'endurance_cache_level', 2 ) ),
-		);
 	}
 
 }

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -30,6 +30,90 @@ class EventManager {
 	private $subscribers = array();
 
 	/**
+	 * The queue of events logged in the current request
+	 *
+	 * @var array
+	 */
+	private $queue = array();
+
+	/**
+	 * Initialize the Event Manager
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->initialize_listeners();
+		$this->initialize_cron();
+
+		// Register the shutdown hook which sends or saves all queued events
+		add_action( 'shutdown', array( $this, 'shutdown' ) );
+	}
+
+	/**
+	 * Handle setting up the scheduled job for sending updates
+	 *
+	 * @return void
+	 */
+	public function initialize_cron() {
+		// Ensure there is a minutely option in the cron schedules
+		add_filter( 'cron_schedules', array( $this, 'add_minutely_schedule' ) );
+
+		// Minutely cron hook
+		add_action( 'bh_data_sync_cron', array( $this, 'send_batch' ) );
+
+		// Register the cron task
+		if ( ! wp_next_scheduled( 'bh_data_sync_cron' ) ) {
+			wp_schedule_event( time() + MINUTE_IN_SECONDS, 'minutely', 'bh_data_sync_cron' );
+		}
+	}
+
+	/**
+	 * Add the weekly option to cron schedules if it doesn't exist
+	 *
+	 * @param array $schedules List of cron schedule options
+	 * @return array
+	 */
+	public function add_minutely_schedule( $schedules ) {
+		if ( ! array_key_exists( 'minutely', $schedules ) || MINUTE_IN_SECONDS !== $schedules['minutely']['interval'] ) {
+			$schedules['minutely'] = array(
+				'interval' => MINUTE_IN_SECONDS,
+				'display'  => __( 'Once Every Minute' ),
+			);
+		}
+		return $schedules;
+	}
+
+	/**
+	 * Sends or saves all queued events at the end of the request
+	 *
+	 * @return void
+	 */
+	public function shutdown() {
+
+		// Separate out the async events
+		$async = array();
+		foreach ( $this->queue as $index => $event ) {
+			if ( 'pageview' === $event->key ) {
+				$async[] = $event;
+				unset( $this->queue[ $index ] );
+			}
+		}
+
+		// Save any async events for sending later
+		if ( ! empty( $async ) ) {
+			if ( ! get_option( 'bh_data_queue_lock' ) ) {
+				$saved_queue = get_option( 'bh_data_queue', array() );
+				update_option( 'bh_data_queue', array_merge( $saved_queue, $async ), false );
+			}
+		}
+
+		// Any remaining items in the queue should be sent now
+		if ( ! empty( $this->queue ) ) {
+			$this->send( $this->queue );
+		}
+	}
+
+	/**
 	 * Register a new event subscriber
 	 *
 	 * @param SubscriberInterface $subscriber Class subscribing to event updates
@@ -71,15 +155,60 @@ class EventManager {
 	}
 
 	/**
-	 * Push event details out to subscribers
+	 * Push event data onto the queue
 	 *
 	 * @param Event $event Details about the action taken
 	 *
 	 * @return void
 	 */
 	public function push( Event $event ) {
+		array_push( $this->queue, $event );
+	}
+
+	/**
+	 * Send queued events to all subscribers
+	 *
+	 * @param array $events A list of events
+	 * @return void
+	 */
+	public function send( $events ) {
 		foreach ( $this->get_subscribers() as $subscriber ) {
-			$subscriber->notify( $event );
+			$subscriber->notify( $events );
 		}
+	}
+
+	/**
+	 * Retrieve a batch of events from the DB queue and shorten it
+	 *
+	 * @param integer $count Number of events to grab from the queue
+	 * @return array
+	 */
+	public function get_batch( $count = 20 ) {
+		$events = get_option( 'bh_data_queue', array() );
+		// Bail early if no saved events
+		if ( empty( $events ) ) {
+			return $events;
+		}
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$batch[] = array_shift( $events );
+		}
+
+		update_option( 'bh_data_queue', $events, false );
+		return $batch;
+	}
+
+	/**
+	 * Send queued events to all subscribers
+	 *
+	 * @return void
+	 */
+	public function send_batch() {
+		add_option( 'bh_data_queue_lock', true );
+		$events = $this->get_batch();
+		if ( ! empty( $events ) ) {
+			$this->send( $events );
+		}
+		delete_option( 'bh_data_queue_lock' );
 	}
 }

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -162,6 +162,7 @@ class EventManager {
 	 * @return void
 	 */
 	public function push( Event $event ) {
+		do_action( 'bh_event_log', $event->key, $event );
 		array_push( $this->queue, $event );
 	}
 

--- a/src/HubConnection.php
+++ b/src/HubConnection.php
@@ -101,8 +101,8 @@ class HubConnection implements SubscriberInterface {
 	 *
 	 * @return boolean
 	 */
-	public function is_connected() {
-		return (bool) ( $this->get_auth_token() );
+	public static function is_connected() {
+		return (bool) ( self::get_auth_token() );
 	}
 
 	/**
@@ -212,7 +212,7 @@ class HubConnection implements SubscriberInterface {
 	public function notify( $events ) {
 
 		// If for some reason we are not connected, bail out now.
-		if ( ! $this->is_connected() ) {
+		if ( ! self::is_connected() ) {
 			return;
 		}
 
@@ -226,7 +226,7 @@ class HubConnection implements SubscriberInterface {
 			'headers'  => array(
 				'Content-Type'  => 'applicaton/json',
 				'Accept'        => 'applicaton/json',
-				'Authorization' => 'Bearer ' . $this->get_auth_token(),
+				'Authorization' => 'Bearer ' . self::get_auth_token(),
 			),
 			'blocking' => false,
 			'timeout'  => .5,
@@ -240,16 +240,12 @@ class HubConnection implements SubscriberInterface {
 	 *
 	 * @return string|null The decrypted token if it's set
 	 */
-	public function get_auth_token() {
-		if ( empty( $this->token ) ) {
-			$encrypted_token = get_option( 'bh_data_token' );
-			if ( false !== $encrypted_token ) {
-				$encryption  = new Encryption();
-				$this->token = $encryption->decrypt( $encrypted_token );
-			}
+	public static function get_auth_token() {
+		$encrypted_token = get_option( 'bh_data_token' );
+		if ( false !== $encrypted_token ) {
+			$encryption = new Encryption();
+			return $encryption->decrypt( $encrypted_token );
 		}
-
-		return $this->token;
 	}
 
 	/**

--- a/src/HubConnection.php
+++ b/src/HubConnection.php
@@ -205,19 +205,24 @@ class HubConnection implements SubscriberInterface {
 	/**
 	 * Post event data payload to the hub
 	 *
-	 * @param Event $event Event object representing the action that occurred
+	 * @param array $events Array of Event objects representing the actions that occurred
 	 *
 	 * @return void
 	 */
-	public function notify( Event $event ) {
+	public function notify( $events ) {
 
 		// If for some reason we are not connected, bail out now.
 		if ( ! $this->is_connected() ) {
 			return;
 		}
 
+		$payload = array(
+			'environment' => $this->get_core_data(),
+			'events'      => $events,
+		);
+
 		$args = array(
-			'body'     => wp_json_encode( $event ),
+			'body'     => wp_json_encode( $payload ),
 			'headers'  => array(
 				'Content-Type'  => 'applicaton/json',
 				'Accept'        => 'applicaton/json',
@@ -227,7 +232,7 @@ class HubConnection implements SubscriberInterface {
 			'timeout'  => .5,
 		);
 
-		wp_remote_post( $this->api . '/event', $args );
+		wp_remote_post( $this->api . '/events', $args );
 	}
 
 	/**

--- a/src/Listeners/Admin.php
+++ b/src/Listeners/Admin.php
@@ -14,8 +14,8 @@ class Admin extends Listener {
 	 */
 	public function register_hooks() {
 		// Admin pages
-		// add_action( 'admin_footer', array( $this, 'view' ), 9 );
-		// add_action( 'customize_controls_print_footer_scripts', array( $this, 'view' ) );
+		add_action( 'admin_footer', array( $this, 'view' ), 9 );
+		add_action( 'customize_controls_print_footer_scripts', array( $this, 'view' ) );
 
 		// Login
 		add_action( 'wp_login', array( $this, 'login' ) );

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -10,10 +10,15 @@ class Logger implements SubscriberInterface {
 	/**
 	 * Method for handling receiving event data
 	 *
-	 * @param Event $event Event object representing data about the event that occurred
+	 * @param array $events Array of Event objects representing data about the events that occurred
 	 */
-	public function notify( Event $event ) {
-		$log = wp_json_encode( $event, JSON_UNESCAPED_SLASHES ) . "\n";
-		file_put_contents( dirname( dirname( __FILE__ ) ) . '/debug.log', $log, FILE_APPEND );
+	public function notify( $events ) {
+		foreach ( $events as $event ) {
+			if ( ! $event ) {
+				return;
+			}
+			$log = wp_json_encode( $event, JSON_UNESCAPED_SLASHES ) . "\n";
+			file_put_contents( dirname( dirname( __FILE__ ) ) . '/debug.log', $log, FILE_APPEND );
+		}
 	}
 }

--- a/src/SubscriberInterface.php
+++ b/src/SubscriberInterface.php
@@ -10,7 +10,7 @@ interface SubscriberInterface {
 	/**
 	 * Method for handling receiving event data
 	 *
-	 * @param Event $event Event object representing data about the event that occurred
+	 * @param array $events Array of Event objects representing data about the events that occurred
 	 */
-	public function notify( Event $event );
+	public function notify( $events );
 }


### PR DESCRIPTION
## Proposed changes

Refactors to support pushing certain event types onto a saved queue that is synced on a cron. This helps performance by preventing extra outbound HTTP requests (even non-blocking ones) in certain situations. 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
