### PR TITLE
add hostgator and fix fatal if constant not found

### DIFF
--- a/src/Helpers/Multibrand.php
+++ b/src/Helpers/Multibrand.php
@@ -21,6 +21,14 @@ class Multibrand {
 				'version' => BLUEHOST_PLUGIN_VERSION,
 			);
 		}
+		if ( defined( 'HOSTGATOR_PLUGIN_VERSION' ) ) {
+			return array(
+				'id' => 'hostgator',
+				'name' => 'HostGator',
+				'slug' => 'hostgator-wordpress-plugin/hostgator-wordpress-plugin.php',
+				'version' => HOSTGATOR_PLUGIN_VERSION,
+			);
+		}
 		if ( defined( 'MM_VERSION' ) ) {
 			return array(
 				'id' => 'mojo',
@@ -29,7 +37,13 @@ class Multibrand {
 				'version' => MM_VERSION,
 			);
 		}
-		return 'unknown';
+		// default
+		return array(
+			'id' => 'error',
+			'name' => 'Error',
+			'slug' => 'error',
+			'version' => '0',
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

This adds the hostgator plugin info to the multibrand helper as well as makes the helper always return an object that won't cause a fatal error.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
