### PR TITLE
Update the hostgator slug after the hostgator plugin was renamed

### DIFF
--- a/src/Helpers/Multibrand.php
+++ b/src/Helpers/Multibrand.php
@@ -25,7 +25,7 @@ class Multibrand {
 			return array(
 				'id' => 'hostgator',
 				'name' => 'HostGator',
-				'slug' => 'hostgator-wordpress-plugin/hostgator-wordpress-plugin.php',
+				'slug' => 'wp-plugin-hostgator/wp-plugin-hostgator.php',
 				'version' => HOSTGATOR_PLUGIN_VERSION,
 			);
 		}


### PR DESCRIPTION
## Proposed changes

Since the hostgator plugin name has changed, this update reflects that in the plugin slug. (Though this is not yet used in the module, there's no rush in getting this out and it can be included in the next release - it will just be good to keep current). 

Currently, we are only using the plugin id and version when establishing a connection in `HubConnection.php get_core_data()`. We opted to just assume plugin based on finding the plugin version constants not sure if slug will ever be needed.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
